### PR TITLE
Coarsened readout

### DIFF
--- a/ModelG/Makefiles/.ipynb_checkpoints/setupprlm-checkpoint.sh
+++ b/ModelG/Makefiles/.ipynb_checkpoints/setupprlm-checkpoint.sh
@@ -1,0 +1,6 @@
+module load spack
+module load spack-config
+PETSC_SPACK_ENV=$CFS/m3722/opt/prlm/petsc-cpu-int64
+spack env activate $PETSC_SPACK_ENV
+spack load petsc
+module load cray-fftw

--- a/ModelG/Makefiles/Makefile.prlm
+++ b/ModelG/Makefiles/Makefile.prlm
@@ -24,7 +24,7 @@ CXX := $(shell pkg-config --variable=cxxcompiler $(PACKAGES))
 FC := $(shell pkg-config --variable=fcompiler $(PACKAGES))
 CFLAGS_OTHER := $(shell pkg-config --cflags-only-other $(PACKAGES))
 CFLAGS := $(shell pkg-config --variable=cflags_extra $(PACKAGES)) $(CFLAGS_OTHER)
-CXXFLAGS := $(shell pkg-config --variable=cxxflags_extra $(PACKAGES)) $(CFLAGS_OTHER) -O3
+CXXFLAGS := $(shell pkg-config --variable=cxxflags_extra $(PACKAGES)) $(CFLAGS_OTHER) -O3 
 FFLAGS := $(shell pkg-config --variable=fflags_extra $(PACKAGES))
 CPPFLAGS := $(shell pkg-config --cflags-only-I $(PACKAGES))
 LDFLAGS := $(shell pkg-config --libs-only-L --libs-only-other $(PACKAGES))

--- a/ModelG/ModelA.h
+++ b/ModelG/ModelA.h
@@ -138,6 +138,8 @@ struct ModelAHandlerData {
   int saveFrequency = 3;
   int writeFrequency = -1;
   int ncoarsen_steps = 3;
+  int ncoarsen_start = 1;
+  int ncoarsen_stride = 1;
 
   bool eventmode = false;
   int nevents = 1;
@@ -162,6 +164,8 @@ struct ModelAHandlerData {
     saveFrequency = params.value("saveFrequency", saveFrequency);
     writeFrequency = params.value("writeFrequency", writeFrequency);
     ncoarsen_steps = params.value("ncoarsen_steps", ncoarsen_steps);
+    ncoarsen_start = params.value("ncoarsen_start", ncoarsen_start);
+    ncoarsen_stride = params.value("ncoarsen_stride", ncoarsen_stride);
 
     eventmode = params.value("eventmode", eventmode);
     nevents = params.value("nevents", nevents);
@@ -184,6 +188,8 @@ struct ModelAHandlerData {
     PetscPrintf(PETSC_COMM_WORLD, "saveFrequency = %d\n", saveFrequency);
     PetscPrintf(PETSC_COMM_WORLD, "writeFrequency = %d\n", writeFrequency);
     PetscPrintf(PETSC_COMM_WORLD, "ncoarsen_steps = %d\n", ncoarsen_steps);
+    PetscPrintf(PETSC_COMM_WORLD, "ncoarsen_start = %d\n", ncoarsen_start);
+    PetscPrintf(PETSC_COMM_WORLD, "ncoarsen_stride = %d\n", ncoarsen_stride);
 
     PetscPrintf(PETSC_COMM_WORLD, "eventmode = %s\n",
                 (eventmode ? "true" : "false"));

--- a/ModelG/ModelA.h
+++ b/ModelG/ModelA.h
@@ -138,6 +138,7 @@ struct ModelAHandlerData {
   std::string outputfiletag = "o4output";
   int saveFrequency = 3;
   int writeFrequency = -1;
+  int ncoarsen_steps = 3;
 
   bool eventmode = false;
   int nevents = 1;
@@ -161,6 +162,7 @@ struct ModelAHandlerData {
     outputfiletag = params.value("outputfiletag", "o4output");
     saveFrequency = params.value("saveFrequency", saveFrequency);
     writeFrequency = params.value("writeFrequency", writeFrequency);
+    ncoarsen_steps = params.value("ncoarsen_steps", ncoarsen_steps);
 
     eventmode = params.value("eventmode", eventmode);
     nevents = params.value("nevents", nevents);
@@ -182,6 +184,7 @@ struct ModelAHandlerData {
                 outputfiletag.c_str());
     PetscPrintf(PETSC_COMM_WORLD, "saveFrequency = %d\n", saveFrequency);
     PetscPrintf(PETSC_COMM_WORLD, "writeFrequency = %d\n", writeFrequency);
+    PetscPrintf(PETSC_COMM_WORLD, "ncoarsen_steps = %d\n", ncoarsen_steps);
 
     PetscPrintf(PETSC_COMM_WORLD, "eventmode = %s\n",
                 (eventmode ? "true" : "false"));

--- a/ModelG/ModelA.h
+++ b/ModelG/ModelA.h
@@ -136,6 +136,7 @@ struct ModelAHandlerData {
   // output files are tag_foo.txt, or tag_bar.h5
   std::string outputfiletag = "o4output";
   int saveFrequency = 3;
+  int saveFrequencyCoarsen = -1;
   int writeFrequency = -1;
   int ncoarsen_steps = 3;
   int ncoarsen_start = 1;
@@ -162,6 +163,7 @@ struct ModelAHandlerData {
     restart = params.value("restart", false);
     outputfiletag = params.value("outputfiletag", "o4output");
     saveFrequency = params.value("saveFrequency", saveFrequency);
+    saveFrequencyCoarsen = params.value("saveFrequencyCoarsen", saveFrequencyCoarsen);
     writeFrequency = params.value("writeFrequency", writeFrequency);
     ncoarsen_steps = params.value("ncoarsen_steps", ncoarsen_steps);
     ncoarsen_start = params.value("ncoarsen_start", ncoarsen_start);
@@ -186,6 +188,7 @@ struct ModelAHandlerData {
     PetscPrintf(PETSC_COMM_WORLD, "outputfiletag = %s\n",
                 outputfiletag.c_str());
     PetscPrintf(PETSC_COMM_WORLD, "saveFrequency = %d\n", saveFrequency);
+    PetscPrintf(PETSC_COMM_WORLD, "saveFrequencyCoarsen = %d\n", saveFrequencyCoarsen);
     PetscPrintf(PETSC_COMM_WORLD, "writeFrequency = %d\n", writeFrequency);
     PetscPrintf(PETSC_COMM_WORLD, "ncoarsen_steps = %d\n", ncoarsen_steps);
     PetscPrintf(PETSC_COMM_WORLD, "ncoarsen_start = %d\n", ncoarsen_start);

--- a/ModelG/Stepper.cxx
+++ b/ModelG/Stepper.cxx
@@ -761,7 +761,7 @@ ModelGDiffusionStep::Form3PointLaplacian(DM da, Mat J, const double &hx,
 
 bool ModelGExplicitDiffusionStep::evolveLocalSolution(const double &dt,
                                                       G_node ***phi,
-                                                      G_node ***phi_new){
+                                                      G_node ***phinew){
 
   auto &data = model->data;
 
@@ -863,7 +863,7 @@ bool ModelGExplicitDiffusionStep::step(const double &dt) {
   PetscCall(DMDAVecGetArray(da, model->solution, &phinew));
 
   // call subroutine that computes phinew
-  evolveLocalSolution(dt, phi, phinew)
+  evolveLocalSolution(dt, phi, phinew);
 
   // restore pointer arrays
   PetscCall(DMDAVecRestoreArray(da, model->solution, &phinew));
@@ -895,8 +895,8 @@ bool ModelGExplicitDiffusionStep::step_coarsening(const double &dt,
 
   for (int i = 0; i < ncoarsen_steps; i++) {
     // Fill in the ghost cells with mpicalls
-    PetscCall(DMGlobalToLocalBegin(da, solution_coarsened, INSERT_VALUES, localU));
-    PetscCall(DMGlobalToLocalEnd(da, solution_coarsened, INSERT_VALUES, localU));
+    PetscCall(DMGlobalToLocalBegin(da, *solution_coarsened, INSERT_VALUES, localU));
+    PetscCall(DMGlobalToLocalEnd(da, *solution_coarsened, INSERT_VALUES, localU));
     // all mpi calls complete: localU is up to date
 
     // get access to arrays indexed using the local dimensions
@@ -904,13 +904,13 @@ bool ModelGExplicitDiffusionStep::step_coarsening(const double &dt,
     // this one needs to also have write access & points to solution_coarsened directly
     // but careful! this only works since we only write to phinew and only read from it locally
     // otherwise, corruption through ghost cells is possible
-    PetscCall(DMDAVecGetArray(da, solution_coarsened, &phinew));
+    PetscCall(DMDAVecGetArray(da, *solution_coarsened, &phinew));
   
     // call subroutine that computes phinew
-    evolveLocalSolution(dt/3., phi, phinew)
+    evolveLocalSolution(dt/3., phi, phinew);
 
     // restore localUnew from phinew
-    PetscCall(DMDAVecRestoreArray(da, solution_coarsened, &phinew));
+    PetscCall(DMDAVecRestoreArray(da, *solution_coarsened, &phinew));
     PetscCall(DMDAVecRestoreArrayRead(da, localU, &phi));
   }
 

--- a/ModelG/Stepper.cxx
+++ b/ModelG/Stepper.cxx
@@ -875,15 +875,15 @@ bool ModelGExplicitDiffusionStep::step(const double &dt) {
   return true;
 }
 
-// call to do a diffusion step that evolves current solution which was deep copied into 
-// solution_coarsened ncoarsen_steps times but does not update the model solution, 
-// but stores it into input solution_coarsened 
-bool ModelGExplicitDiffusionStep::step_coarsening(const double &dt, 
-                                                  Vec *solution_coarsened) {
+// call to do a diffusion step that evolves current solution which was deep copied into
+// solution_coarsened nsteps coarsen-steps (each = 3 diffusion steps) but does not
+// update the model solution, but stores it into input solution_coarsened
+bool ModelGExplicitDiffusionStep::step_coarsening(const double &dt,
+                                                  Vec *solution_coarsened,
+                                                  int nsteps) {
 
-  auto &data = model->data;
-  // diffusive steps will be dt/3., so multiply by 3 
-  int ncoarsen_steps = 3 * data.ahandler.ncoarsen_steps;
+  // each coarsen step consists of 3 diffusion steps with dt/3
+  int ndiffusion_steps = 3 * nsteps;
 
   // Get a local vector with ghost cells
   DM da = model->domain;
@@ -893,7 +893,7 @@ bool ModelGExplicitDiffusionStep::step_coarsening(const double &dt,
   // pointer arrays
   G_node ***phi, ***phinew;
 
-  for (int i = 0; i < ncoarsen_steps; i++) {
+  for (int i = 0; i < ndiffusion_steps; i++) {
     // Fill in the ghost cells with mpicalls
     PetscCall(DMGlobalToLocalBegin(da, *solution_coarsened, INSERT_VALUES, localU));
     PetscCall(DMGlobalToLocalEnd(da, *solution_coarsened, INSERT_VALUES, localU));

--- a/ModelG/Stepper.cxx
+++ b/ModelG/Stepper.cxx
@@ -759,24 +759,14 @@ ModelGDiffusionStep::Form3PointLaplacian(DM da, Mat J, const double &hx,
 
 /////////////////////////////////////////////////////////////////////////
 
-bool ModelGExplicitDiffusionStep::step(const double &dt) {
+bool ModelGExplicitDiffusionStep::evolveLocalSolution(const double &dt,
+                                                      G_node ***phi,
+                                                      G_node ***phi_new){
 
   auto &data = model->data;
 
   // Get a local vector with ghost cells
   DM da = model->domain;
-  Vec localU;
-  PetscCall(DMGetLocalVector(da, &localU));
-
-  // Fill in the ghost celss with mpicalls
-  PetscCall(DMGlobalToLocalBegin(da, model->solution, INSERT_VALUES, localU));
-  PetscCall(DMGlobalToLocalEnd(da, model->solution, INSERT_VALUES, localU));
-
-  // Get Access to arrays with drifted solution
-  G_node ***phi;
-  PetscCall(DMDAVecGetArrayRead(da, localU, &phi));
-  G_node ***phinew;
-  PetscCall(DMDAVecGetArray(da, model->solution, &phinew));
 
   const auto &coeff = data.acoefficients;
   PetscReal H[4] = {coeff.H, 0., 0., 0.};
@@ -846,8 +836,85 @@ bool ModelGExplicitDiffusionStep::step(const double &dt) {
       }
     }
   }
+
+  return true;
+}
+
+// call to do a diffusion step that evolves current solution and updates it 
+bool ModelGExplicitDiffusionStep::step(const double &dt) {
+
+  auto &data = model->data;
+
+  // Get a local vector (buffer) with ghost cells
+  DM da = model->domain;
+  Vec localU;
+  PetscCall(DMGetLocalVector(da, &localU));
+
+  // Fill in the ghost celss with mpicalls
+  PetscCall(DMGlobalToLocalBegin(da, model->solution, INSERT_VALUES, localU));
+  PetscCall(DMGlobalToLocalEnd(da, model->solution, INSERT_VALUES, localU));
+
+  G_node ***phi, ***phinew;
+  // get access to arrays indexed using the local dimensions
+  PetscCall(DMDAVecGetArrayRead(da, localU, &phi));
+  // this one needs to also have write access & points to the solution directly
+  // but careful! this only works since we only write to phinew and only read from it locally
+  // otherwise, corruption through ghost cells is possible
+  PetscCall(DMDAVecGetArray(da, model->solution, &phinew));
+
+  // call subroutine that computes phinew
+  evolveLocalSolution(dt, phi, phinew)
+
+  // restore pointer arrays
   PetscCall(DMDAVecRestoreArray(da, model->solution, &phinew));
   PetscCall(DMDAVecRestoreArrayRead(da, localU, &phi));
+
+  // restore local vectors
+  PetscCall(DMRestoreLocalVector(da, &localU));
+
+  return true;
+}
+
+// call to do a diffusion step that evolves current solution which was deep copied into 
+// solution_coarsened ncoarsen_steps times but does not update the model solution, 
+// but stores it into input solution_coarsened 
+bool ModelGExplicitDiffusionStep::step_coarsening(const double &dt, 
+                                                  Vec *solution_coarsened) {
+
+  auto &data = model->data;
+  // diffusive steps will be dt/3., so multiply by 3 
+  int ncoarsen_steps = 3 * data.ahandler.ncoarsen_steps;
+
+  // Get a local vector with ghost cells
+  DM da = model->domain;
+  Vec localU;
+  PetscCall(DMGetLocalVector(da, &localU));
+
+  // pointer arrays
+  G_node ***phi, ***phinew;
+
+  for (int i = 0; i < ncoarsen_steps; i++) {
+    // Fill in the ghost cells with mpicalls
+    PetscCall(DMGlobalToLocalBegin(da, solution_coarsened, INSERT_VALUES, localU));
+    PetscCall(DMGlobalToLocalEnd(da, solution_coarsened, INSERT_VALUES, localU));
+    // all mpi calls complete: localU is up to date
+
+    // get access to arrays indexed using the local dimensions
+    PetscCall(DMDAVecGetArrayRead(da, localU, &phi));
+    // this one needs to also have write access & points to solution_coarsened directly
+    // but careful! this only works since we only write to phinew and only read from it locally
+    // otherwise, corruption through ghost cells is possible
+    PetscCall(DMDAVecGetArray(da, solution_coarsened, &phinew));
+  
+    // call subroutine that computes phinew
+    evolveLocalSolution(dt/3., phi, phinew)
+
+    // restore localUnew from phinew
+    PetscCall(DMDAVecRestoreArray(da, solution_coarsened, &phinew));
+    PetscCall(DMDAVecRestoreArrayRead(da, localU, &phi));
+  }
+
+  // Restore local vectors after loop
   PetscCall(DMRestoreLocalVector(da, &localU));
 
   return true;

--- a/ModelG/Stepper.h
+++ b/ModelG/Stepper.h
@@ -200,7 +200,7 @@ class ModelGExplicitDiffusionStep : public Stepper {
 public:
   ModelGExplicitDiffusionStep(ModelA &in) : model(&in) { ; }
   bool step(const double &dt) override;
-  bool step_coarsening(const double &dt, Vec *solution_coarsened);
+  bool step_coarsening(const double &dt, Vec *solution_coarsened, int nsteps = 1);
   void finalize() override { ; }
   ~ModelGExplicitDiffusionStep() { ; }
 

--- a/ModelG/Stepper.h
+++ b/ModelG/Stepper.h
@@ -200,11 +200,13 @@ class ModelGExplicitDiffusionStep : public Stepper {
 public:
   ModelGExplicitDiffusionStep(ModelA &in) : model(&in) { ; }
   bool step(const double &dt) override;
+  bool step_coarsening(const double &dt, Vec *solution_coarsened);
   void finalize() override { ; }
   ~ModelGExplicitDiffusionStep() { ; }
 
 private:
   ModelA *model;
+  bool evolveLocalSolution(const double &dt, G_node ***phi, G_node ***phinew);
 };
 /////////////////////////////////////////////////////////////////////////
 

--- a/ModelG/SuperPions.cxx
+++ b/ModelG/SuperPions.cxx
@@ -169,6 +169,16 @@ void run_event(const int &ievent, ModelA *const model, Stepper *const step,
       PetscLogEventEnd(measurements, 0, 0, 0, 0);
     }
 
+    // on separate frequency: measure coarsen solution
+    if (ahandler.saveFrequencyCoarsen > 0 and steps % ahandler.saveFrequencyCoarsen == 0) {
+      PetscLogEventBegin(measurements, 0, 0, 0, 0);
+      measurer.measure_coarsen(&model->solution);
+      if (rank == 0) {
+        measurer_output->save_coarsen();
+      }
+      PetscLogEventEnd(measurements, 0, 0, 0, 0);
+    }
+
     // Write the solution to tape if writeFrequency > 0. This is used for
     // plotting of the solution. It is normally not analyzed, or written.
     if (ahandler.writeFrequency > 0 and steps % ahandler.writeFrequency == 0) {

--- a/ModelG/SuperPions.cxx
+++ b/ModelG/SuperPions.cxx
@@ -16,6 +16,7 @@
 #include "measurer.h"
 #include "measurer_output.h"
 
+
 void thermalize_event(ModelA *const model) {
   const auto &ahandler = model->data.ahandler;
   auto &atime = model->data.atime;

--- a/ModelG/compile_jg.sh
+++ b/ModelG/compile_jg.sh
@@ -1,2 +1,6 @@
+#!  /usr/bin/bash
+
+source Makefiles/setupprlm.sh
+make -f Makefiles/Makefile.prlm clean
 make -f Makefiles/Makefile.prlm SuperPions.exe
 mv SuperPions.exe ../../

--- a/ModelG/compile_jg.sh
+++ b/ModelG/compile_jg.sh
@@ -1,0 +1,2 @@
+make -f Makefiles/Makefile.prlm SuperPions.exe
+mv SuperPions.exe ../../

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -310,7 +310,7 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
           // project phi
           for (int l = 0; l < ModelAData::Nphi; l++) {
             // project phi
-            phi[l] = phi[l] - phi_s/norm2_c * n[l];
+            //phi[l] = phi[l] - phi_s/norm2_c * n[l];
             // normalize n to unity
             n[l] = n[l] / sqrt(norm2_c);
           }

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -83,7 +83,7 @@ void Measurer::computeSliceAverage(Vec *solution) {
     }
   }
 
-  // Retstore the array
+  // Restore the array
   DMDAVecRestoreArrayRead(da, localU, &fld);
   DMRestoreLocalVector(da, &localU);
 
@@ -219,6 +219,156 @@ void Measurer::computeSliceAveragePhase(Vec *solution) {
   }
 }
 
+// takes the solution, evolves it with diffusion stepper and locally decomposes solution 
+// along the diffused solution
+void Measurer::computeSliceAverageCoarsened(Vec *solution) {
+  
+  // Get the local information
+  DM &da = model->domain;
+  const auto &data = model->data;
+  const auto &coeff = data.acoefficients;
+
+  Vec localU, localU_coarsened;
+  G_node ***fld, ***fld_coarsened;
+  // localU has the dimensions of the local domain
+  DMGetLocalVector(da, &localU);
+  DMGetLocalVector(da, &localU_coarsened);
+  // take the global solution and distribute to the local vector localU
+  DMGlobalToLocalBegin(da, *solution, INSERT_VALUES, localU);
+  DMGlobalToLocalEnd(da, *solution, INSERT_VALUES, localU);
+  // From the vector define the pointer for the field phi
+  DMDAVecGetArrayRead(da, localU, &fld);
+
+  // first, deep copy solution into solution_coarsened
+  PetscCall(VecCopy(*solution, solution_coarsened));
+  // do the coarsening step (this is done by the subroutine of ModelGExplicitDiffusionStep) 
+  // and store the coarsened current solution in solution_coarsened 
+  diffuser->step_coarsening(data.atime.dt(), &solution_coarsened);
+
+  // convert solution_coarsened to a local 3d array
+  DMGlobalToLocalBegin(da, *solution_coarsened, INSERT_VALUES, localU_coarsened);
+  DMGlobalToLocalEnd(da, *solution_coarsened, INSERT_VALUES, localU_coarsened);
+  DMDAVecGetArrayRead(da, localU_coarsened, &fld_coarsened);
+  
+  // Set up the slize averages initialized to zero in c++11
+  std::fill(wallXCoarse.v.begin(), wallXCoarse.v.end(), 0.);
+  std::fill(wallYCoarse.v.begin(), wallYCoarse.v.end(), 0.);
+  std::fill(wallZCoarse.v.begin(), wallZCoarse.v.end(), 0.);
+
+  // Local arrays with same dimensions initialized to zero
+  nvector<double, 2> wallXCoarseLocal(NObsCoarse, N);
+  nvector<double, 2> wallYCoarseLocal(NObsCoarse, N);
+  nvector<double, 2> wallZCoarseLocal(NObsCoarse, N);
+
+  // Get the ranges
+  PetscInt ixs, iys, izs, nx, ny, nz;
+  DMDAGetCorners(da, &ixs, &iys, &izs, &nx, &ny, &nz);
+
+  double sigma;
+  std::array<double, 4> n{};
+  std::array<double, 4> phi{};
+  std::array<double, 6> rho{};
+  std::array<double, 4> V{};
+  std::array<double, 4> A{};
+  // Store the local averages
+  for (int k = izs; k < izs + nz; k++) {
+    for (int j = iys; j < iys + ny; j++) {
+      for (int i = ixs; i < ixs + nx; i++) {
+
+        // Gram-Schmidt procedure:
+        // phi_project = phi - <phi, phi_coarse>/<phi_coarse, phi_coarse> phi_coarse
+
+        double norm2_c = 0.0;   // <phi_coarse, phi_coarse>
+        double norm2 = 0.0;     // <phi, phi>
+        double phi_s = 0.0;     // <phi, phi_coarse>
+        for (int l=0; l < ModelAData::Nphi; l++){
+          // unnormalized coarse spin
+          n[l] = fld_coarsened[k][j][i].f[l];
+          // solution spin
+          phi[l] = fld[k][j][i].f[l];
+          // scalar product
+          phi_s += n[l]*phi[l];
+          // norm_c
+          norm2_c += pow(n[l], 2);
+          // norm
+          norm2 += pow(phi[l], 2);
+        }
+        // sigma is norm of projected which is
+        // norm = sqrt(<phi, phi> - 2<phi_coarse, phi>^2/<phi_coarse, phi_coarse>
+        //             + <phi, phi_coarse>^2 / <phi_coarse, phi_coarse> )
+        //      = sqrt(norm2 - 2phi_s^2/norm2_c + phi_s^2/norm2_c )
+        sigma = sqrt(norm2 - 2.0*phi_s*phi_s/norm2_c + phi_s*phi_s/norm2_c );
+        // store charge fields
+        for (int l = 0; l < ModelAData::NA; l++) {
+          rho[l] = fld[k][j][i].A[l];
+          rho[l + ModelAData::NA] = fld[k][j][i].V[l];
+        }
+        // project phi
+        for (int l = 0; l < ModelAData::Nphi; l++) {
+          // project phi
+          phi[l] = phi[l] - phi_s/norm2_c * n[l];
+          // rescale phi_project: phi_rescale = phi_proj * f /sigma
+          phi[l] = phi[l] * sqrt(coeff.f2(data.atime.t())) / sigma;
+          // normalize n to unity
+          n[l] = n[l] / sqrt(norm2_c);
+        }
+        // project charge fields
+        A = contract_rho(n, rho);
+        V = contract_rho(n, dualize_rho(rho));
+
+
+        // store projected in wall*CoarseLocal
+        
+        wallXCoarseLocal(0, i) += sigma;
+        wallYCoarseLocal(0, j) += sigma;
+        wallZCoarseLocal(0, k) += sigma;
+        for (int l = 0; l < ModelAData::Nphi; l++) {
+          wallXCoarseLocal(1 + l, i) += n[l];
+          wallYCoarseLocal(1 + l, j) += n[l];
+          wallZCoarseLocal(1 + l, k) += n[l];
+
+          wallXCoarseLocal(5 + l, i) += A[l];
+          wallYCoarseLocal(5 + l, j) += A[l];
+          wallZCoarseLocal(5 + l, k) += A[l];
+
+          wallXCoarseLocal(9 + l, i) += V[l];
+          wallYCoarseLocal(9 + l, j) += V[l];
+          wallZCoarseLocal(9 + l, k) += V[l];
+        }
+        wallXCoarseLocal(Measurer::NObsCoarse - 1, i) += sigma * sigma;
+        wallYCoarseLocal(Measurer::NObsCoarse - 1, j) += sigma * sigma;
+        wallZCoarseLocal(Measurer::NObsCoarse - 1, k) += sigma * sigma;
+      }
+    }
+  }
+
+  // normalize by 1/N^2
+  for (int l = 0; l < NObsCoarse; ++l) {
+    for (int i = 0; i < N; ++i) {
+      wallXCoarseLocal(l, i) /= PetscReal(N * N);
+      wallYCoarseLocal(l, i) /= PetscReal(N * N);
+      wallZCoarseLocal(l, i) /= PetscReal(N * N);
+    }
+  }
+
+  // Retstore the array
+  DMDAVecRestoreArrayRead(da, localU, &fld);
+  DMRestoreLocalVector(da, &localU);
+  DMDAVecRestoreArrayRead(da, localU_coarsened, &fld_coarsened);
+  DMRestoreLocalVector(da, &localU_coarsened);
+
+  // Bring all the data x data into one
+  for (int l = 0; l < NObsCoarse; l++) {
+    MPI_Reduce(&wallXCoarseLocal(l, 0), &wallXCoarse(l, 0), N, MPIU_SCALAR,
+               MPI_SUM, 0, PETSC_COMM_WORLD);
+    MPI_Reduce(&wallYCoarseLocal(l, 0), &wallYCoarse(l, 0), N, MPIU_SCALAR,
+               MPI_SUM, 0, PETSC_COMM_WORLD);
+    MPI_Reduce(&wallZCoarseLocal(l, 0), &wallZCoarse(l, 0), N, MPIU_SCALAR,
+               MPI_SUM, 0, PETSC_COMM_WORLD);
+  }
+}
+
+
 // Given the fourier transform of phi_a(t,k) and other fields
 // stored in the wallk strucutre, compute the rotated fields
 // The zero mode has phi(t,0) defines a unit four vector n_a
@@ -313,4 +463,348 @@ void Measurer::computeDerivedObs() {
   fftw->execute(wallXPhase, wallXPhase_k);
   fftw->execute(wallYPhase, wallYPhase_k);
   fftw->execute(wallZPhase, wallZPhase_k);
+
+  fftw->execute(wallXCoarse, wallXCoarse_k);
+  fftw->execute(wallYCoarse, wallYCoarse_k);
+  fftw->execute(wallZCoarse, wallZCoarse_k);
+}
+
+// Routine: compute different terms that contribute to total energy and 
+// store inside Energy[NEnergy]
+// 
+// H = H_s + H_A + H_V + H_H
+// H: total energy - Energy[0]
+// H_s: spin field gradient term - Energy[1]
+// H_A: axial charge field term - Energy[2]
+// H_V: vector charge field term - Energy[3]
+// H_H: term induced by presence of magnetic field - Energy[4]
+void Measurer::computeEnergy() {
+  DM da = model->domain;
+  // Get a local vector with ghost cells
+  Vec localUNew;
+  DMGetLocalVector(da, &localUNew);
+
+  // Fill in the ghost celss with mpicalls
+
+  DMGlobalToLocalBegin(da, model->solution, INSERT_VALUES, localUNew);
+  DMGlobalToLocalEnd(da, model->solution, INSERT_VALUES, localUNew);
+
+  const auto &data = model->data;
+  const auto &coeff = data.acoefficients;
+
+  G_node ***phiNew;
+  DMDAVecGetArrayRead(da, localUNew, &phiNew);
+
+  const PetscReal H[4] = {coeff.sigmabyf(model->data.atime.t())*coeff.H, 0., 0., 0.};
+
+  PetscInt xstart, ystart, zstart, xdimension, ydimension, zdimension;
+  DMDAGetCorners(da, &xstart, &ystart, &zstart, &xdimension, &ydimension,
+                 &zdimension);
+
+  // Loop over central elements
+  PetscScalar phimid = 0, grad2 = 0, nA2 = 0, nV2 = 0, hEn = 0;
+
+  for (PetscInt k = zstart; k < zstart + zdimension; k++) {
+    for (PetscInt j = ystart; j < ystart + ydimension; j++) {
+      for (PetscInt i = xstart; i < xstart + xdimension; i++) {
+        for (int s = 0; s < ModelAData::Nphi; ++s) {
+
+          phimid = phiNew[k][j][i].f[s];
+
+          grad2 += pow(phiNew[k + 1][j][i].f[s] - phimid, 2);
+          grad2 += pow(phiNew[k][j + 1][i].f[s] - phimid, 2);
+          grad2 += pow(phiNew[k][j][i + 1].f[s] - phimid, 2);
+
+          hEn += phimid * H[s];
+        }
+        for (PetscInt s = 0; s < ModelAData::NV; s++) {
+          nV2 += pow(phiNew[k][j][i].V[s], 2);
+        }
+
+        for (PetscInt s = 0; s < ModelAData::NA; s++) {
+          nA2 += pow(phiNew[k][j][i].A[s], 2);
+        }
+      }
+    }
+  }
+
+  Energy = std::vector<PetscScalar>(NEnergy, 0.);
+  std::vector<PetscScalar> EnergyLocal(NEnergy, 0.);
+    
+  EnergyLocal[1] = 0.5 / pow(PetscReal(N),3) * grad2;
+  EnergyLocal[2] = 0.5 / pow(PetscReal(N),3) / coeff.chi * nA2;
+  EnergyLocal[3] = 0.5 / pow(PetscReal(N),3) / coeff.chi * nV2;
+  EnergyLocal[4] = -1.0 / pow(PetscReal(N),3) * hEn;
+
+  for (int l = 1; l < NEnergy; l++) {
+     EnergyLocal[0] += EnergyLocal[l];
+  }
+
+  MPI_Reduce(&EnergyLocal[0], &Energy[0], NEnergy, MPIU_SCALAR, MPI_SUM, 0,
+             PETSC_COMM_WORLD);
+
+  DMDAVecRestoreArrayRead(da, localUNew, &phiNew);
+  DMRestoreLocalVector(da, &localUNew);
+
+}
+
+// Routine: compute different terms that contribute to total energy and 
+// store inside EnergyRotated[NEnergy]
+// 
+// H = H_s + H_A + H_V + H_H
+// H: total energy - Energy[0]
+// H_s: pion field gradient term - Energy[1]
+// H_A: rotated axial charge field term - Energy[2]
+// H_V: rotated vector charge field term - Energy[3]
+// H_m2: pion field mass term - Energy[4]
+void Measurer::computeEnergyRotated() {
+  DM da = model->domain;
+  // Get a local vector with ghost cells
+  Vec localUNew;
+  DMGetLocalVector(da, &localUNew);
+
+  // Fill in the ghost celss with mpicalls
+
+  DMGlobalToLocalBegin(da, model->solution, INSERT_VALUES, localUNew);
+  DMGlobalToLocalEnd(da, model->solution, INSERT_VALUES, localUNew);
+
+  const auto &data = model->data;
+  const auto &coeff = data.acoefficients;
+
+  G_node ***phiNew;
+  DMDAVecGetArrayRead(da, localUNew, &phiNew);
+
+  const PetscReal m2 = coeff.sigmabyf(data.atime.t())*coeff.H/sqrt(coeff.f2(data.atime.t()));
+
+  PetscInt xstart, ystart, zstart, xdimension, ydimension, zdimension;
+  DMDAGetCorners(da, &xstart, &ystart, &zstart, &xdimension, &ydimension,
+                 &zdimension);
+
+  // rotated fields
+  std::array<PetscScalar, ModelAData::Nphi> n{};
+  std::array<PetscScalar, ModelAData::Nphi> phi{};
+  std::array<PetscScalar, ModelAData::Nphi> phir{};
+  std::array<PetscScalar, ModelAData::Nphi> phi_xplus{};
+  std::array<PetscScalar, ModelAData::Nphi> phir_xplus{};
+  std::array<PetscScalar, ModelAData::Nphi> phi_yplus{};
+  std::array<PetscScalar, ModelAData::Nphi> phir_yplus{};
+  std::array<PetscScalar, ModelAData::Nphi> phi_zplus{};
+  std::array<PetscScalar, ModelAData::Nphi> phir_zplus{};
+  std::array<PetscScalar, 6> rho{};
+  std::array<PetscScalar, 4> V{};
+  std::array<PetscScalar, 4> A{};
+
+  // Loop over central elements
+  PetscScalar phimid = 0, grad2 = 0, nA2 = 0, nV2 = 0, hEn = 0;
+
+  // Extract the vev direction
+  double norm = 0.; 
+  for (int a = 0; a < 4; a++) {
+    n[a] = wallX_k(a, 0).real(); // Extract the zero mode  of phi_a
+    norm += std::norm(n[a]);
+  }
+  norm = sqrt(norm);
+  if (norm < std::numeric_limits<double>::min()) {
+    n = std::array<PetscScalar, 4>{1, 0, 0, 0};
+  } 
+  else {
+    for (size_t a = 0; a < 4; a++) {
+      n[a] /= norm;
+    }
+  }
+      
+  for (PetscInt k = zstart; k < zstart + zdimension; k++) {
+    for (PetscInt j = ystart; j < ystart + ydimension; j++) {
+      for (PetscInt i = xstart; i < xstart + xdimension; i++) {
+        // Do the rotation to vev
+        for (PetscInt s = 0; s < ModelAData::Nphi; s++) {
+          phi[s] = phiNew[k][j][i].f[s];
+          phi_xplus[s] = phiNew[k][j][i+1].f[s];
+          phi_yplus[s] = phiNew[k][j+1][i].f[s];
+          phi_zplus[s] = phiNew[k+1][j][i].f[s];
+        }
+        for (PetscInt s = 0; s < ModelAData::NA; s++) {
+          rho[s] = phiNew[k][j][i].A[s];
+        }
+        for (PetscInt s = 0; s < ModelAData::NV; s++) {
+          rho[s + ModelAData::NA] = phiNew[k][j][i].V[s];
+        }
+
+        PetscScalar phis(0.);
+        PetscScalar phis_xplus(0.);
+        PetscScalar phis_yplus(0.);
+        PetscScalar phis_zplus(0.);
+        for (size_t a = 0; a < 4; a++) {
+          phis += n[a] * phi[a];
+          phis_xplus += n[a] * phi_xplus[a];
+          phis_yplus += n[a] * phi_yplus[a];
+          phis_zplus += n[a] * phi_zplus[a];  
+        }
+        for (size_t a = 0; a < 4; a++) {
+          phir[a] = phi[a] - n[a] * phis;
+          phir_xplus[a] = phi_xplus[a] - n[a] * phis_xplus;
+          phir_yplus[a] = phi_yplus[a] - n[a] * phis_yplus;  
+          phir_zplus[a] = phi_zplus[a] - n[a] * phis_zplus;  
+        }
+        A = contract_rho(n, rho);
+        V = contract_rho(n, dualize_rho(rho));
+        
+        for (int s = 1; s < ModelAData::Nphi; s++) {
+
+          phimid = phir[s];
+
+          grad2 += pow(phi_zplus[s] - phimid, 2);
+          grad2 += pow(phi_yplus[s] - phimid, 2);
+          grad2 += pow(phi_xplus[s] - phimid, 2);
+
+          if (s!=0){  
+            grad2 += m2 * pow(phimid, 2);
+          }    
+        }
+        //hEn -= phi[0];
+        for (PetscInt s = 0; s < 4; s++) {
+          nV2 += pow(V[s], 2);
+        }
+
+        for (PetscInt s = 0; s < 4; s++) {
+          nA2 += pow(A[s], 2);
+        }
+      }
+    }
+  }
+
+  EnergyRotated = std::vector<PetscScalar>(NEnergy, 0.);
+  std::vector<PetscScalar> EnergyLocal(NEnergy, 0.);
+    
+  EnergyLocal[1] = 0.5 / pow(PetscReal(N),3) * grad2;
+  EnergyLocal[2] = 0.5 / pow(PetscReal(N),3) / coeff.chi * nA2;
+  EnergyLocal[3] = 0.5 / pow(PetscReal(N),3) / coeff.chi * nV2;
+  EnergyLocal[4] = coeff.sigmabyf(model->data.atime.t())*coeff.H / pow(PetscReal(N),3) * hEn;
+
+  for (int l = 1; l < NEnergy; l++) {
+     EnergyLocal[0] += EnergyLocal[l];
+  }
+
+  MPI_Reduce(&EnergyLocal[0], &EnergyRotated[0], NEnergy, MPIU_SCALAR, MPI_SUM, 0,
+             PETSC_COMM_WORLD);
+
+  DMDAVecRestoreArrayRead(da, localUNew, &phiNew);
+  DMRestoreLocalVector(da, &localUNew);
+
+}
+
+// Routine: compute different terms that contribute to total energy and 
+// store inside EnergyPhase[NEnergy]
+// 
+// H = H_s + H_A + H_V + H_H
+// H: total energy - Energy[0]
+// H_s: phase field gradient term - Energy[1]
+// H_A: phase axial charge field term - Energy[2]
+// H_V: phase vector charge field term - Energy[3]
+// H_m2: phase field mass term - Energy[4]
+void Measurer::computeEnergyPhase() {
+  DM da = model->domain;
+  // Get a local vector with ghost cells
+  Vec localUNew;
+  DMGetLocalVector(da, &localUNew);
+
+  // Fill in the ghost celss with mpicalls
+
+  DMGlobalToLocalBegin(da, model->solution, INSERT_VALUES, localUNew);
+  DMGlobalToLocalEnd(da, model->solution, INSERT_VALUES, localUNew);
+
+  const auto &data = model->data;
+  const auto &coeff = data.acoefficients;
+
+  G_node ***phiNew;
+  DMDAVecGetArrayRead(da, localUNew, &phiNew);
+
+  const PetscReal m2 = coeff.sigmabyf(data.atime.t())*coeff.H/sqrt(coeff.f2(data.atime.t()));
+    
+  PetscInt xstart, ystart, zstart, xdimension, ydimension, zdimension;
+  DMDAGetCorners(da, &xstart, &ystart, &zstart, &xdimension, &ydimension,
+                 &zdimension);
+
+  // rotated fields
+  std::array<PetscScalar, ModelAData::Nphi> n{};
+  std::array<PetscScalar, ModelAData::Nphi> phi{};
+  std::array<PetscScalar, 6> rho{};
+  std::array<PetscScalar, 4> V{};
+  std::array<PetscScalar, 4> A{};
+
+  // Loop over central elements
+  PetscScalar phimid = 0, grad2 = 0, grad2_0 = 0, nA2 = 0, nV2 = 0, hEn = 0, hEn_0 = 0;
+      
+  for (PetscInt k = zstart; k < zstart + zdimension; k++) {
+    for (PetscInt j = ystart; j < ystart + ydimension; j++) {
+      for (PetscInt i = xstart; i < xstart + xdimension; i++) {
+        double norm = 0.0;
+        for (int l = 0; l < ModelAData::Nphi; l++) {
+          phi[l] = phiNew[k][j][i].f[l];
+          norm += pow(phi[l], 2);
+        }
+        norm = sqrt(norm);
+
+        if (norm > 100. * std::numeric_limits<double>::min()) {
+          for (int l = 0; l < ModelAData::Nphi; l++) {
+            n[l] = phi[l] / norm;
+          }
+        } else {
+          n = {1, 0, 0, 0};
+        }
+
+        for (int l = 0; l < ModelAData::NA; l++) {
+          rho[l] = phiNew[k][j][i].A[l];
+          rho[l + ModelAData::NA] = phiNew[k][j][i].V[l];
+        }
+        A = contract_rho(n, rho);
+        V = contract_rho(n, dualize_rho(rho));
+
+        
+        for (int s = 0; s < ModelAData::Nphi; s++) {
+
+          phimid = phiNew[k][j][i].f[s];
+
+          if (s==0){
+            grad2_0 += pow(phiNew[k + 1][j][i].f[s] - phimid, 2);
+            grad2_0 += pow(phiNew[k][j + 1][i].f[s] - phimid, 2);
+            grad2_0 += pow(phiNew[k][j][i + 1].f[s] - phimid, 2);
+            //hEn_0 += pow(phimid, 2);  
+          }  
+          else {
+            grad2 += pow(phiNew[k + 1][j][i].f[s] - phimid, 2);
+            grad2 += pow(phiNew[k][j + 1][i].f[s] - phimid, 2);
+            grad2 += pow(phiNew[k][j][i + 1].f[s] - phimid, 2);
+            hEn += pow(phimid, 2);  
+          }    
+        }
+        for (PetscInt s = 0; s < 4; s++) {
+          nV2 += pow(V[s], 2);
+        }
+
+        for (PetscInt s = 0; s < 4; s++) {
+          nA2 += pow(A[s], 2);
+        }
+      }
+    }
+  }
+
+  EnergyPhase = std::vector<PetscScalar>(NEnergy, 0.);
+  std::vector<PetscScalar> EnergyLocal(NEnergy, 0.);
+    
+  EnergyLocal[1] = 0.5 / pow(PetscReal(N),3) * (grad2 + m2 * hEn);
+  EnergyLocal[2] = 0.5 / pow(PetscReal(N),3) / coeff.chi * nA2;
+  EnergyLocal[3] = 0.5 / pow(PetscReal(N),3) / coeff.chi * nV2;
+  EnergyLocal[4] =  0.5 / pow(PetscReal(N),3) * (grad2_0); // + m2 * hEn_0);
+
+  for (int l = 1; l < NEnergy; l++) {
+     EnergyLocal[0] += EnergyLocal[l];
+  }
+
+  MPI_Reduce(&EnergyLocal[0], &EnergyPhase[0], NEnergy, MPIU_SCALAR, MPI_SUM, 0,
+             PETSC_COMM_WORLD);
+
+  DMDAVecRestoreArrayRead(da, localUNew, &phiNew);
+  DMRestoreLocalVector(da, &localUNew);
+
 }

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -290,14 +290,12 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
           phi_s += n[l]*phi[l];
           // norm_c
           norm2_c += pow(n[l], 2);
-          // norm
-          norm2 += pow(phi[l], 2);
         }
         // sigma is norm of projected which is
         // norm = sqrt(<phi, phi> - 2<phi_coarse, phi>^2/<phi_coarse, phi_coarse>
         //             + <phi, phi_coarse>^2 / <phi_coarse, phi_coarse> )
-        //      = sqrt(norm2 - 2phi_s^2/norm2_c + phi_s^2/norm2_c )
-        sigma = sqrt(norm2 - 2.0*phi_s*phi_s/norm2_c + phi_s*phi_s/norm2_c );
+        //      = sqrt(norm2 - phi_s^2/norm2_c )
+        sigma = sqrt(norm2 - phi_s*phi_s/norm2_c );
         // store charge fields
         for (int l = 0; l < ModelAData::NA; l++) {
           rho[l] = fld[k][j][i].A[l];
@@ -307,8 +305,6 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
         for (int l = 0; l < ModelAData::Nphi; l++) {
           // project phi
           phi[l] = phi[l] - phi_s/norm2_c * n[l];
-          // rescale phi_project: phi_rescale = phi_proj * f /sigma
-          phi[l] = phi[l] * sqrt(coeff.f2(data.atime.t())) / sigma;
           // normalize n to unity
           n[l] = n[l] / sqrt(norm2_c);
         }

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -226,7 +226,6 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
   // Get the local information
   DM &da = model->domain;
   const auto &data = model->data;
-  const auto &coeff = data.acoefficients;
 
   Vec localU, localU_coarsened;
   G_node ***fld, ***fld_coarsened;
@@ -240,14 +239,14 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
   DMDAVecGetArrayRead(da, localU, &fld);
 
   // first, deep copy solution into solution_coarsened
-  PetscCall(VecCopy(*solution, solution_coarsened));
+  VecCopy(*solution, solution_coarsened);
   // do the coarsening step (this is done by the subroutine of ModelGExplicitDiffusionStep) 
   // and store the coarsened current solution in solution_coarsened 
   diffuser->step_coarsening(data.atime.dt(), &solution_coarsened);
 
   // convert solution_coarsened to a local 3d array
-  DMGlobalToLocalBegin(da, *solution_coarsened, INSERT_VALUES, localU_coarsened);
-  DMGlobalToLocalEnd(da, *solution_coarsened, INSERT_VALUES, localU_coarsened);
+  DMGlobalToLocalBegin(da, solution_coarsened, INSERT_VALUES, localU_coarsened);
+  DMGlobalToLocalEnd(da, solution_coarsened, INSERT_VALUES, localU_coarsened);
   DMDAVecGetArrayRead(da, localU_coarsened, &fld_coarsened);
   
   // Set up the slize averages initialized to zero in c++11

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -290,6 +290,8 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
           phi_s += n[l]*phi[l];
           // norm_c
           norm2_c += pow(n[l], 2);
+          // norm2
+          norm2 += pow(phi[l], 2);
         }
         // sigma is norm of projected which is
         // norm = sqrt(<phi, phi> - 2<phi_coarse, phi>^2/<phi_coarse, phi_coarse>

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -245,10 +245,13 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
   PetscInt ixs, iys, izs, nx, ny, nz;
   DMDAGetCorners(da, &ixs, &iys, &izs, &nx, &ny, &nz);
 
-  // Loop over coarsen levels: index c stores result after c+1 coarsen steps
-  for (int c = 0; c < ncoarsen_steps; c++) {
-    // Apply 1 more coarsen step (= 3 diffusion steps with dt/3)
-    diffuser->step_coarsening(data.atime.dt(), &solution_coarsened, 1);
+  // Iterate through selected coarsen levels, applying incremental steps between them
+  int current_step = 0;
+  for (int c = 0; c < static_cast<int>(coarsen_levels.size()); c++) {
+    int steps_to_apply = coarsen_levels[c] - current_step;
+    // Apply the remaining steps to reach the next selected level
+    diffuser->step_coarsening(data.atime.dt(), &solution_coarsened, steps_to_apply);
+    current_step = coarsen_levels[c];
 
     // convert solution_coarsened to a local 3d array
     DMGlobalToLocalBegin(da, solution_coarsened, INSERT_VALUES, localU_coarsened);
@@ -463,7 +466,7 @@ void Measurer::computeDerivedObs() {
   fftw->execute(wallYPhase, wallYPhase_k);
   fftw->execute(wallZPhase, wallZPhase_k);
 
-  for (int c = 0; c < ncoarsen_steps; c++) {
+  for (int c = 0; c < static_cast<int>(coarsen_levels.size()); c++) {
     fftw->execute(wallXCoarse[c], wallXCoarse_k[c]);
     fftw->execute(wallYCoarse[c], wallYCoarse_k[c]);
     fftw->execute(wallZCoarse[c], wallZCoarse_k[c]);

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -219,10 +219,10 @@ void Measurer::computeSliceAveragePhase(Vec *solution) {
   }
 }
 
-// takes the solution, evolves it with diffusion stepper and locally decomposes solution 
-// along the diffused solution
+// takes the solution, evolves it with diffusion stepper and locally decomposes solution
+// along the diffused solution; repeats for each coarsen level 1..ncoarsen_steps
 void Measurer::computeSliceAverageCoarsened(Vec *solution) {
-  
+
   // Get the local information
   DM &da = model->domain;
   const auto &data = model->data;
@@ -238,131 +238,133 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
   // From the vector define the pointer for the field phi
   DMDAVecGetArrayRead(da, localU, &fld);
 
-  // first, deep copy solution into solution_coarsened
+  // deep copy solution into solution_coarsened; will be evolved one step at a time
   VecCopy(*solution, solution_coarsened);
-  // do the coarsening step (this is done by the subroutine of ModelGExplicitDiffusionStep) 
-  // and store the coarsened current solution in solution_coarsened 
-  diffuser->step_coarsening(data.atime.dt(), &solution_coarsened);
 
-  // convert solution_coarsened to a local 3d array
-  DMGlobalToLocalBegin(da, solution_coarsened, INSERT_VALUES, localU_coarsened);
-  DMGlobalToLocalEnd(da, solution_coarsened, INSERT_VALUES, localU_coarsened);
-  DMDAVecGetArrayRead(da, localU_coarsened, &fld_coarsened);
-  
-  // Set up the slize averages initialized to zero in c++11
-  std::fill(wallXCoarse.v.begin(), wallXCoarse.v.end(), 0.);
-  std::fill(wallYCoarse.v.begin(), wallYCoarse.v.end(), 0.);
-  std::fill(wallZCoarse.v.begin(), wallZCoarse.v.end(), 0.);
-
-  // Local arrays with same dimensions initialized to zero
-  nvector<double, 2> wallXCoarseLocal(NObsCoarse, N);
-  nvector<double, 2> wallYCoarseLocal(NObsCoarse, N);
-  nvector<double, 2> wallZCoarseLocal(NObsCoarse, N);
-
-  // Get the ranges
+  // Get the ranges (same for all coarsen levels)
   PetscInt ixs, iys, izs, nx, ny, nz;
   DMDAGetCorners(da, &ixs, &iys, &izs, &nx, &ny, &nz);
 
-  double sigma;
-  std::array<double, 4> n{};
-  std::array<double, 4> phi{};
-  std::array<double, 6> rho{};
-  std::array<double, 4> V{};
-  std::array<double, 4> A{};
-  // Store the local averages
-  for (int k = izs; k < izs + nz; k++) {
-    for (int j = iys; j < iys + ny; j++) {
-      for (int i = ixs; i < ixs + nx; i++) {
+  // Loop over coarsen levels: index c stores result after c+1 coarsen steps
+  for (int c = 0; c < ncoarsen_steps; c++) {
+    // Apply 1 more coarsen step (= 3 diffusion steps with dt/3)
+    diffuser->step_coarsening(data.atime.dt(), &solution_coarsened, 1);
 
-        // Gram-Schmidt procedure:
-        // phi_project = phi - <phi, phi_coarse>/<phi_coarse, phi_coarse> phi_coarse
+    // convert solution_coarsened to a local 3d array
+    DMGlobalToLocalBegin(da, solution_coarsened, INSERT_VALUES, localU_coarsened);
+    DMGlobalToLocalEnd(da, solution_coarsened, INSERT_VALUES, localU_coarsened);
+    DMDAVecGetArrayRead(da, localU_coarsened, &fld_coarsened);
 
-        double norm2_c = 0.0;   // <phi_coarse, phi_coarse>
-        double norm2 = 0.0;     // <phi, phi>
-        double phi_s = 0.0;     // <phi, phi_coarse>
-        for (int l=0; l < ModelAData::Nphi; l++){
-          // unnormalized coarse spin
-          n[l] = fld_coarsened[k][j][i].f[l];
-          // solution spin
-          phi[l] = fld[k][j][i].f[l];
-          // scalar product
-          phi_s += n[l]*phi[l];
-          // norm_c
-          norm2_c += pow(n[l], 2);
-          // norm2
-          norm2 += pow(phi[l], 2);
-        }
-        // sigma is norm of projected which is
-        // norm = sqrt(<phi, phi> - 2<phi_coarse, phi>^2/<phi_coarse, phi_coarse>
-        //             + <phi, phi_coarse>^2 / <phi_coarse, phi_coarse> )
-        //      = sqrt(norm2 - phi_s^2/norm2_c )
-        sigma = sqrt(norm2 - phi_s*phi_s/norm2_c );
-        // store charge fields
-        for (int l = 0; l < ModelAData::NA; l++) {
-          rho[l] = fld[k][j][i].A[l];
-          rho[l + ModelAData::NA] = fld[k][j][i].V[l];
-        }
-        // project phi
-        for (int l = 0; l < ModelAData::Nphi; l++) {
+    // Set up the slice averages initialized to zero
+    std::fill(wallXCoarse[c].v.begin(), wallXCoarse[c].v.end(), 0.);
+    std::fill(wallYCoarse[c].v.begin(), wallYCoarse[c].v.end(), 0.);
+    std::fill(wallZCoarse[c].v.begin(), wallZCoarse[c].v.end(), 0.);
+
+    // Local arrays with same dimensions initialized to zero
+    nvector<double, 2> wallXCoarseLocal(NObsCoarse, N);
+    nvector<double, 2> wallYCoarseLocal(NObsCoarse, N);
+    nvector<double, 2> wallZCoarseLocal(NObsCoarse, N);
+
+    double sigma;
+    std::array<double, 4> n{};
+    std::array<double, 4> phi{};
+    std::array<double, 6> rho{};
+    std::array<double, 4> V{};
+    std::array<double, 4> A{};
+    // Store the local averages
+    for (int k = izs; k < izs + nz; k++) {
+      for (int j = iys; j < iys + ny; j++) {
+        for (int i = ixs; i < ixs + nx; i++) {
+
+          // Gram-Schmidt procedure:
+          // phi_project = phi - <phi, phi_coarse>/<phi_coarse, phi_coarse> phi_coarse
+
+          double norm2_c = 0.0;   // <phi_coarse, phi_coarse>
+          double norm2 = 0.0;     // <phi, phi>
+          double phi_s = 0.0;     // <phi, phi_coarse>
+          for (int l=0; l < ModelAData::Nphi; l++){
+            // unnormalized coarse spin
+            n[l] = fld_coarsened[k][j][i].f[l];
+            // solution spin
+            phi[l] = fld[k][j][i].f[l];
+            // scalar product
+            phi_s += n[l]*phi[l];
+            // norm_c
+            norm2_c += pow(n[l], 2);
+            // norm2
+            norm2 += pow(phi[l], 2);
+          }
+          // sigma is norm of projected which is
+          // norm = sqrt(<phi, phi> - 2<phi_coarse, phi>^2/<phi_coarse, phi_coarse>
+          //             + <phi, phi_coarse>^2 / <phi_coarse, phi_coarse> )
+          //      = sqrt(norm2 - phi_s^2/norm2_c )
+          sigma = sqrt(norm2 - phi_s*phi_s/norm2_c );
+          // store charge fields
+          for (int l = 0; l < ModelAData::NA; l++) {
+            rho[l] = fld[k][j][i].A[l];
+            rho[l + ModelAData::NA] = fld[k][j][i].V[l];
+          }
           // project phi
-          phi[l] = phi[l] - phi_s/norm2_c * n[l];
-          // normalize n to unity
-          n[l] = n[l] / sqrt(norm2_c);
+          for (int l = 0; l < ModelAData::Nphi; l++) {
+            // project phi
+            phi[l] = phi[l] - phi_s/norm2_c * n[l];
+            // normalize n to unity
+            n[l] = n[l] / sqrt(norm2_c);
+          }
+          // project charge fields
+          A = contract_rho(n, rho);
+          V = contract_rho(n, dualize_rho(rho));
+
+          // store projected in wall*CoarseLocal
+          wallXCoarseLocal(0, i) += sigma;
+          wallYCoarseLocal(0, j) += sigma;
+          wallZCoarseLocal(0, k) += sigma;
+          for (int l = 0; l < ModelAData::Nphi; l++) {
+            wallXCoarseLocal(1 + l, i) += n[l];
+            wallYCoarseLocal(1 + l, j) += n[l];
+            wallZCoarseLocal(1 + l, k) += n[l];
+
+            wallXCoarseLocal(5 + l, i) += A[l];
+            wallYCoarseLocal(5 + l, j) += A[l];
+            wallZCoarseLocal(5 + l, k) += A[l];
+
+            wallXCoarseLocal(9 + l, i) += V[l];
+            wallYCoarseLocal(9 + l, j) += V[l];
+            wallZCoarseLocal(9 + l, k) += V[l];
+          }
+          wallXCoarseLocal(Measurer::NObsCoarse - 1, i) += sigma * sigma;
+          wallYCoarseLocal(Measurer::NObsCoarse - 1, j) += sigma * sigma;
+          wallZCoarseLocal(Measurer::NObsCoarse - 1, k) += sigma * sigma;
         }
-        // project charge fields
-        A = contract_rho(n, rho);
-        V = contract_rho(n, dualize_rho(rho));
-
-
-        // store projected in wall*CoarseLocal
-        
-        wallXCoarseLocal(0, i) += sigma;
-        wallYCoarseLocal(0, j) += sigma;
-        wallZCoarseLocal(0, k) += sigma;
-        for (int l = 0; l < ModelAData::Nphi; l++) {
-          wallXCoarseLocal(1 + l, i) += n[l];
-          wallYCoarseLocal(1 + l, j) += n[l];
-          wallZCoarseLocal(1 + l, k) += n[l];
-
-          wallXCoarseLocal(5 + l, i) += A[l];
-          wallYCoarseLocal(5 + l, j) += A[l];
-          wallZCoarseLocal(5 + l, k) += A[l];
-
-          wallXCoarseLocal(9 + l, i) += V[l];
-          wallYCoarseLocal(9 + l, j) += V[l];
-          wallZCoarseLocal(9 + l, k) += V[l];
-        }
-        wallXCoarseLocal(Measurer::NObsCoarse - 1, i) += sigma * sigma;
-        wallYCoarseLocal(Measurer::NObsCoarse - 1, j) += sigma * sigma;
-        wallZCoarseLocal(Measurer::NObsCoarse - 1, k) += sigma * sigma;
       }
     }
-  }
 
-  // normalize by 1/N^2
-  for (int l = 0; l < NObsCoarse; ++l) {
-    for (int i = 0; i < N; ++i) {
-      wallXCoarseLocal(l, i) /= PetscReal(N * N);
-      wallYCoarseLocal(l, i) /= PetscReal(N * N);
-      wallZCoarseLocal(l, i) /= PetscReal(N * N);
+    // normalize by 1/N^2
+    for (int l = 0; l < NObsCoarse; ++l) {
+      for (int i = 0; i < N; ++i) {
+        wallXCoarseLocal(l, i) /= PetscReal(N * N);
+        wallYCoarseLocal(l, i) /= PetscReal(N * N);
+        wallZCoarseLocal(l, i) /= PetscReal(N * N);
+      }
+    }
+
+    DMDAVecRestoreArrayRead(da, localU_coarsened, &fld_coarsened);
+
+    // Bring all the data into one
+    for (int l = 0; l < NObsCoarse; l++) {
+      MPI_Reduce(&wallXCoarseLocal(l, 0), &wallXCoarse[c](l, 0), N, MPIU_SCALAR,
+                 MPI_SUM, 0, PETSC_COMM_WORLD);
+      MPI_Reduce(&wallYCoarseLocal(l, 0), &wallYCoarse[c](l, 0), N, MPIU_SCALAR,
+                 MPI_SUM, 0, PETSC_COMM_WORLD);
+      MPI_Reduce(&wallZCoarseLocal(l, 0), &wallZCoarse[c](l, 0), N, MPIU_SCALAR,
+                 MPI_SUM, 0, PETSC_COMM_WORLD);
     }
   }
 
-  // Retstore the array
+  // Restore the uncoarsened arrays
   DMDAVecRestoreArrayRead(da, localU, &fld);
   DMRestoreLocalVector(da, &localU);
-  DMDAVecRestoreArrayRead(da, localU_coarsened, &fld_coarsened);
   DMRestoreLocalVector(da, &localU_coarsened);
-
-  // Bring all the data x data into one
-  for (int l = 0; l < NObsCoarse; l++) {
-    MPI_Reduce(&wallXCoarseLocal(l, 0), &wallXCoarse(l, 0), N, MPIU_SCALAR,
-               MPI_SUM, 0, PETSC_COMM_WORLD);
-    MPI_Reduce(&wallYCoarseLocal(l, 0), &wallYCoarse(l, 0), N, MPIU_SCALAR,
-               MPI_SUM, 0, PETSC_COMM_WORLD);
-    MPI_Reduce(&wallZCoarseLocal(l, 0), &wallZCoarse(l, 0), N, MPIU_SCALAR,
-               MPI_SUM, 0, PETSC_COMM_WORLD);
-  }
 }
 
 
@@ -461,9 +463,11 @@ void Measurer::computeDerivedObs() {
   fftw->execute(wallYPhase, wallYPhase_k);
   fftw->execute(wallZPhase, wallZPhase_k);
 
-  fftw->execute(wallXCoarse, wallXCoarse_k);
-  fftw->execute(wallYCoarse, wallYCoarse_k);
-  fftw->execute(wallZCoarse, wallZCoarse_k);
+  for (int c = 0; c < ncoarsen_steps; c++) {
+    fftw->execute(wallXCoarse[c], wallXCoarse_k[c]);
+    fftw->execute(wallYCoarse[c], wallYCoarse_k[c]);
+    fftw->execute(wallZCoarse[c], wallZCoarse_k[c]);
+  }
 }
 
 // Routine: compute different terms that contribute to total energy and 

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -323,9 +323,9 @@ void Measurer::computeSliceAverageCoarsened(Vec *solution) {
           wallYCoarseLocal(0, j) += sigma;
           wallZCoarseLocal(0, k) += sigma;
           for (int l = 0; l < ModelAData::Nphi; l++) {
-            wallXCoarseLocal(1 + l, i) += n[l];
-            wallYCoarseLocal(1 + l, j) += n[l];
-            wallZCoarseLocal(1 + l, k) += n[l];
+            wallXCoarseLocal(1 + l, i) += phi[l];
+            wallYCoarseLocal(1 + l, j) += phi[l];
+            wallZCoarseLocal(1 + l, k) += phi[l];
 
             wallXCoarseLocal(5 + l, i) += A[l];
             wallYCoarseLocal(5 + l, j) += A[l];

--- a/ModelG/measurer.cxx
+++ b/ModelG/measurer.cxx
@@ -465,6 +465,11 @@ void Measurer::computeDerivedObs() {
   fftw->execute(wallXPhase, wallXPhase_k);
   fftw->execute(wallYPhase, wallYPhase_k);
   fftw->execute(wallZPhase, wallZPhase_k);
+}
+
+void Measurer::computeDerivedObs_coarsen() {
+  // NB: the intent is that this is to be called only
+  // from the rank=0
 
   for (int c = 0; c < static_cast<int>(coarsen_levels.size()); c++) {
     fftw->execute(wallXCoarse[c], wallXCoarse_k[c]);

--- a/ModelG/measurer.h
+++ b/ModelG/measurer.h
@@ -195,7 +195,7 @@ public:
     wallZCoarse_k.resize(NObsCoarse, N / 2 + 1);
 
     // create unique diffusion stepper
-    diffuser = std::make_unique<ModelGExplicitDiffusionStep>(model);
+    diffuser = std::make_unique<ModelGExplicitDiffusionStep>(*model);
     // create global vector that stores coarsened solution
     DMCreateGlobalVector(model->domain, &solution_coarsened);
   }

--- a/ModelG/measurer.h
+++ b/ModelG/measurer.h
@@ -214,6 +214,11 @@ public:
     diffuser = std::make_unique<ModelGExplicitDiffusionStep>(*model);
     // create global vector that stores coarsened solution
     DMCreateGlobalVector(model->domain, &solution_coarsened);
+
+    PetscLogEventRegister("Energy_measure", 0, &energy_log);
+    PetscLogEventRegister("Normal+Phase_measure", 0, &convt_log);
+    PetscLogEventRegister("Coarsen_measure", 0, &coarsen_log);
+    PetscLogEventRegister("Derived_measure", 0, &derived_log);
   }
 
   virtual ~Measurer() {}
@@ -223,19 +228,30 @@ public:
   // wallX_rotated, as well as Y and Z are filled with the data. This can be
   // accessed to write the data to disk.
   void measure(Vec *solution) {
+
     int rank = -1;
     MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
 
+    PetscLogEventBegin(convt_log, 0, 0, 0, 0);
     computeSliceAverage(solution);
     computeSliceAveragePhase(solution);
+    PetscLogEventEnd(convt_log, 0, 0, 0, 0);
+    
+    PetscLogEventBegin(coarsen_log, 0, 0, 0, 0);
     computeSliceAverageCoarsened(solution);
+    PetscLogEventEnd(coarsen_log, 0, 0, 0, 0);
+    
+    PetscLogEventBegin(energy_log, 0, 0, 0, 0);
     computeEnergy();
     computeEnergyRotated();
     computeEnergyPhase();
+    PetscLogEventEnd(energy_log, 0, 0, 0, 0);
 
     // Take the FFT and other steps based on the data collected
     if (rank == 0) {
+      PetscLogEventBegin(derived_log, 0, 0, 0, 0);
       computeDerivedObs();
+      PetscLogEventEnd(derived_log, 0, 0, 0, 0);
     }
   }
 
@@ -260,6 +276,8 @@ private:
   std::unique_ptr<measurer_fft> fftw;
   // Diffusion stepper to coarsen/diffuse the solution
   std::unique_ptr<ModelGExplicitDiffusionStep> diffuser;
+    
+  PetscLogEvent energy_log, convt_log, coarsen_log, derived_log;
 };
 
 #endif

--- a/ModelG/measurer.h
+++ b/ModelG/measurer.h
@@ -4,6 +4,7 @@
 #include "ModelA.h"
 // #include "make_unique.h"
 #include "nvector.h"
+#include "Stepper.h"
 #include <array>
 #include <complex>
 #include <fftw3.h>
@@ -95,6 +96,12 @@ public:
   static const PetscInt NScalars = NObs;
   std::vector<PetscScalar> OAverage;
 
+  // energy data (different parts of H)
+  static const PetscInt NEnergy = 5;
+  std::vector<PetscScalar> Energy;
+  std::vector<PetscScalar> EnergyRotated;
+  std::vector<PetscScalar> EnergyPhase;
+
   // First dimension is NObs, last is spatial index x=0...N
   nvector<PetscScalar, 2> wallX;
   nvector<PetscScalar, 2> wallY;
@@ -125,6 +132,20 @@ public:
   nvector<std::complex<double>, 2> wallXPhase_k;
   nvector<std::complex<double>, 2> wallYPhase_k;
   nvector<std::complex<double>, 2> wallZPhase_k;
+
+  // Array of size NObsCoarse contains XCoarse = (sigma, pi[1..Nphi],
+  // q[1..2*Nphi], phi2)
+  // The first dimension is NObsCoarse, the second dimension is the spatial index
+  static const PetscInt NObsCoarse = 3 * ModelAData::Nphi + 2;
+  Vec solution_coarsened;
+  nvector<PetscScalar, 2> wallXCoarse;
+  nvector<PetscScalar, 2> wallYCoarse;
+  nvector<PetscScalar, 2> wallZCoarse;
+
+  // First dimension is NObsCoarse, last dimension is the fourier index 0..N/2+1
+  nvector<std::complex<double>, 2> wallXCoarse_k;
+  nvector<std::complex<double>, 2> wallYCoarse_k;
+  nvector<std::complex<double>, 2> wallZCoarse_k;
 
 public:
   Measurer(ModelA *ptr) : model(ptr) {
@@ -164,6 +185,19 @@ public:
     wallXPhase_k.resize(NObsPhase, N / 2 + 1);
     wallYPhase_k.resize(NObsPhase, N / 2 + 1);
     wallZPhase_k.resize(NObsPhase, N / 2 + 1);
+
+    wallXCoarse.resize(NObsCoarse, N);
+    wallYCoarse.resize(NObsCoarse, N);
+    wallZCoarse.resize(NObsCoarse, N);
+
+    wallXCoarse_k.resize(NObsCoarse, N / 2 + 1);
+    wallYCoarse_k.resize(NObsCoarse, N / 2 + 1);
+    wallZCoarse_k.resize(NObsCoarse, N / 2 + 1);
+
+    // create unique diffusion stepper
+    diffuser = std::make_unique<ModelGExplicitDiffusionStep>(model);
+    // create global vector that stores coarsened solution
+    DMCreateGlobalVector(model->domain, &solution_coarsened);
   }
 
   virtual ~Measurer() {}
@@ -191,6 +225,10 @@ public:
 private:
   void computeSliceAverage(Vec *solution);
   void computeSliceAveragePhase(Vec *solution);
+  void computeSliceAverageCoarsened(Vec *solution);
+  void computeEnergy();
+  void computeEnergyRotated();
+  void computeEnergyPhase();
   void computeDerivedObs();
 
   ModelA *model;
@@ -198,6 +236,8 @@ private:
 
   // FFT engine using the fftw3 library
   std::unique_ptr<measurer_fft> fftw;
+  // Diffusion stepper to coarsen/diffuse the solution
+  std::unique_ptr<Stepper> diffuser;
 };
 
 #endif

--- a/ModelG/measurer.h
+++ b/ModelG/measurer.h
@@ -138,14 +138,16 @@ public:
   // The first dimension is NObsCoarse, the second dimension is the spatial index
   static const PetscInt NObsCoarse = 3 * ModelAData::Nphi + 2;
   Vec solution_coarsened;
-  nvector<PetscScalar, 2> wallXCoarse;
-  nvector<PetscScalar, 2> wallYCoarse;
-  nvector<PetscScalar, 2> wallZCoarse;
+  int ncoarsen_steps;
+  // Vectors of length ncoarsen_steps; index c holds result for c+1 coarsen steps
+  std::vector<nvector<PetscScalar, 2>> wallXCoarse;
+  std::vector<nvector<PetscScalar, 2>> wallYCoarse;
+  std::vector<nvector<PetscScalar, 2>> wallZCoarse;
 
   // First dimension is NObsCoarse, last dimension is the fourier index 0..N/2+1
-  nvector<std::complex<double>, 2> wallXCoarse_k;
-  nvector<std::complex<double>, 2> wallYCoarse_k;
-  nvector<std::complex<double>, 2> wallZCoarse_k;
+  std::vector<nvector<std::complex<double>, 2>> wallXCoarse_k;
+  std::vector<nvector<std::complex<double>, 2>> wallYCoarse_k;
+  std::vector<nvector<std::complex<double>, 2>> wallZCoarse_k;
 
 public:
   Measurer(ModelA *ptr) : model(ptr) {
@@ -186,13 +188,21 @@ public:
     wallYPhase_k.resize(NObsPhase, N / 2 + 1);
     wallZPhase_k.resize(NObsPhase, N / 2 + 1);
 
-    wallXCoarse.resize(NObsCoarse, N);
-    wallYCoarse.resize(NObsCoarse, N);
-    wallZCoarse.resize(NObsCoarse, N);
-
-    wallXCoarse_k.resize(NObsCoarse, N / 2 + 1);
-    wallYCoarse_k.resize(NObsCoarse, N / 2 + 1);
-    wallZCoarse_k.resize(NObsCoarse, N / 2 + 1);
+    ncoarsen_steps = model->data.ahandler.ncoarsen_steps;
+    wallXCoarse.resize(ncoarsen_steps);
+    wallYCoarse.resize(ncoarsen_steps);
+    wallZCoarse.resize(ncoarsen_steps);
+    wallXCoarse_k.resize(ncoarsen_steps);
+    wallYCoarse_k.resize(ncoarsen_steps);
+    wallZCoarse_k.resize(ncoarsen_steps);
+    for (int c = 0; c < ncoarsen_steps; c++) {
+      wallXCoarse[c].resize(NObsCoarse, N);
+      wallYCoarse[c].resize(NObsCoarse, N);
+      wallZCoarse[c].resize(NObsCoarse, N);
+      wallXCoarse_k[c].resize(NObsCoarse, N / 2 + 1);
+      wallYCoarse_k[c].resize(NObsCoarse, N / 2 + 1);
+      wallZCoarse_k[c].resize(NObsCoarse, N / 2 + 1);
+    }
 
     // create unique diffusion stepper
     diffuser = std::make_unique<ModelGExplicitDiffusionStep>(*model);
@@ -225,6 +235,7 @@ public:
 
   ModelA *getModel() { return model; }
   PetscInt getN() { return N; }
+  int getNCoarsenSteps() { return ncoarsen_steps; }
 
 private:
   void computeSliceAverage(Vec *solution);

--- a/ModelG/measurer.h
+++ b/ModelG/measurer.h
@@ -237,10 +237,6 @@ public:
     computeSliceAveragePhase(solution);
     PetscLogEventEnd(convt_log, 0, 0, 0, 0);
     
-    PetscLogEventBegin(coarsen_log, 0, 0, 0, 0);
-    computeSliceAverageCoarsened(solution);
-    PetscLogEventEnd(coarsen_log, 0, 0, 0, 0);
-    
     PetscLogEventBegin(energy_log, 0, 0, 0, 0);
     computeEnergy();
     computeEnergyRotated();
@@ -251,6 +247,22 @@ public:
     if (rank == 0) {
       PetscLogEventBegin(derived_log, 0, 0, 0, 0);
       computeDerivedObs();
+      PetscLogEventEnd(derived_log, 0, 0, 0, 0);
+    }
+  }
+
+  void measure_coarsen(Vec * solution){
+    int rank = -1;
+    MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
+    
+    PetscLogEventBegin(coarsen_log, 0, 0, 0, 0);
+    computeSliceAverageCoarsened(solution);
+    PetscLogEventEnd(coarsen_log, 0, 0, 0, 0);
+    
+    // Take the FFT and other steps based on the data collected
+    if (rank == 0) {
+      PetscLogEventBegin(derived_log, 0, 0, 0, 0);
+      computeDerivedObs_coarsen();
       PetscLogEventEnd(derived_log, 0, 0, 0, 0);
     }
   }

--- a/ModelG/measurer.h
+++ b/ModelG/measurer.h
@@ -138,8 +138,9 @@ public:
   // The first dimension is NObsCoarse, the second dimension is the spatial index
   static const PetscInt NObsCoarse = 3 * ModelAData::Nphi + 2;
   Vec solution_coarsened;
-  int ncoarsen_steps;
-  // Vectors of length ncoarsen_steps; index c holds result for c+1 coarsen steps
+  // Selected coarsen levels to record: ncoarsen_start, ncoarsen_start+stride, ...
+  std::vector<int> coarsen_levels;
+  // Vectors of length coarsen_levels.size(); index c holds result for coarsen_levels[c] steps
   std::vector<nvector<PetscScalar, 2>> wallXCoarse;
   std::vector<nvector<PetscScalar, 2>> wallYCoarse;
   std::vector<nvector<PetscScalar, 2>> wallZCoarse;
@@ -188,14 +189,19 @@ public:
     wallYPhase_k.resize(NObsPhase, N / 2 + 1);
     wallZPhase_k.resize(NObsPhase, N / 2 + 1);
 
-    ncoarsen_steps = model->data.ahandler.ncoarsen_steps;
-    wallXCoarse.resize(ncoarsen_steps);
-    wallYCoarse.resize(ncoarsen_steps);
-    wallZCoarse.resize(ncoarsen_steps);
-    wallXCoarse_k.resize(ncoarsen_steps);
-    wallYCoarse_k.resize(ncoarsen_steps);
-    wallZCoarse_k.resize(ncoarsen_steps);
-    for (int c = 0; c < ncoarsen_steps; c++) {
+    {
+      const auto &h = model->data.ahandler;
+      for (int s = h.ncoarsen_start; s <= h.ncoarsen_steps; s += h.ncoarsen_stride)
+        coarsen_levels.push_back(s);
+    }
+    int nout = static_cast<int>(coarsen_levels.size());
+    wallXCoarse.resize(nout);
+    wallYCoarse.resize(nout);
+    wallZCoarse.resize(nout);
+    wallXCoarse_k.resize(nout);
+    wallYCoarse_k.resize(nout);
+    wallZCoarse_k.resize(nout);
+    for (int c = 0; c < nout; c++) {
       wallXCoarse[c].resize(NObsCoarse, N);
       wallYCoarse[c].resize(NObsCoarse, N);
       wallZCoarse[c].resize(NObsCoarse, N);
@@ -235,7 +241,8 @@ public:
 
   ModelA *getModel() { return model; }
   PetscInt getN() { return N; }
-  int getNCoarsenSteps() { return ncoarsen_steps; }
+  int getNCoarsenOutputs() { return static_cast<int>(coarsen_levels.size()); }
+  const std::vector<int> &getCoarsenLevels() { return coarsen_levels; }
 
 private:
   void computeSliceAverage(Vec *solution);

--- a/ModelG/measurer.h
+++ b/ModelG/measurer.h
@@ -212,6 +212,10 @@ public:
 
     computeSliceAverage(solution);
     computeSliceAveragePhase(solution);
+    computeSliceAverageCoarsened(solution);
+    computeEnergy();
+    computeEnergyRotated();
+    computeEnergyPhase();
 
     // Take the FFT and other steps based on the data collected
     if (rank == 0) {
@@ -237,7 +241,7 @@ private:
   // FFT engine using the fftw3 library
   std::unique_ptr<measurer_fft> fftw;
   // Diffusion stepper to coarsen/diffuse the solution
-  std::unique_ptr<Stepper> diffuser;
+  std::unique_ptr<ModelGExplicitDiffusionStep> diffuser;
 };
 
 #endif

--- a/ModelG/measurer_output.cxx
+++ b/ModelG/measurer_output.cxx
@@ -31,6 +31,12 @@ measurer_output_fasthdf5::measurer_output_fasthdf5(Measurer *in,
 
   std::array<size_t, 1> NN1{Measurer::NScalars};
   scalars = std::make_unique<ntuple<1>>(NN1, "phi", file_id);
+  NN1 = {Measurer::NEnergy};
+  energy = std::make_unique<ntuple<1>>(NN1, "energy", file_id);
+  NN1 = {Measurer::NEnergy};
+  energy_rotated = std::make_unique<ntuple<1>>(NN1, "energy_rotated", file_id);
+  NN1 = {Measurer::NEnergy};
+  energy_phase = std::make_unique<ntuple<1>>(NN1, "energy_phase", file_id);
   NN1 = {2};
   timeout = std::make_unique<ntuple<1>>(NN1, "timeout", file_id);
 
@@ -64,6 +70,14 @@ measurer_output_fasthdf5::measurer_output_fasthdf5(Measurer *in,
   wallx_phase_k = std::make_unique<ntuple<3>>(NN3, "wallx_phase_k", file_id);
   wally_phase_k = std::make_unique<ntuple<3>>(NN3, "wally_phase_k", file_id);
   wallz_phase_k = std::make_unique<ntuple<3>>(NN3, "wallz_phase_k", file_id);
+
+  NN3 = {Measurer::NObsCoarse, static_cast<size_t>(measure->getN()) / 2 + 1, 2};
+  wallx_coarsened_k = std::make_unique<ntuple<3>>(NN3, "wallx_coarsened_k",
+                                                  file_id);
+  wally_coarsened_k = std::make_unique<ntuple<3>>(NN3, "wally_coarsened_k",
+                                                  file_id);
+  wallz_coarsened_k = std::make_unique<ntuple<3>>(NN3, "wallz_coarsened_k",
+                                                  file_id);
 }
 
 measurer_output_fasthdf5::~measurer_output_fasthdf5() { H5Fclose(file_id); }
@@ -76,6 +90,15 @@ void measurer_output_fasthdf5::save(const std::string &what) {
 
   scalars->row = measure->OAverage;
   scalars->fill();
+
+  energy->row = measure->Energy;
+  energy->fill();
+
+  energy_rotated->row = measure->EnergyRotated;
+  energy_rotated->fill();
+
+  energy_phase->row = measure->EnergyPhase;
+  energy_phase->fill();
 
   wallx->row = measure->wallX.v;
   wally->row = measure->wallY.v;
@@ -127,6 +150,17 @@ void measurer_output_fasthdf5::save(const std::string &what) {
   wallx_phase_k->fill();
   wally_phase_k->fill();
   wallz_phase_k->fill();
+
+  std::memcpy(wallx_coarsened_k->row.data(), measure->wallXCoarse_k.v.data(),
+              wallx_coarsened_k->row.size() * sizeof(double));
+  std::memcpy(wally_coarsened_k->row.data(), measure->wallYCoarse_k.v.data(),
+              wally_coarsened_k->row.size() * sizeof(double));
+  std::memcpy(wallz_coarsened_k->row.data(), measure->wallZCoarse_k.v.data(),
+              wallz_coarsened_k->row.size() * sizeof(double));
+
+  wallx_coarsened_k->fill();
+  wally_coarsened_k->fill();
+  wallz_coarsened_k->fill();
 }
 #endif
 

--- a/ModelG/measurer_output.cxx
+++ b/ModelG/measurer_output.cxx
@@ -69,12 +69,16 @@ measurer_output_fasthdf5::measurer_output_fasthdf5(Measurer *in,
   wallz_phase_k = std::make_unique<ntuple<3>>(NN3, "wallz_phase_k", file_id);
 
   NN3 = {Measurer::NObsCoarse, static_cast<size_t>(measure->getN()) / 2 + 1, 2};
-  wallx_coarsened_k = std::make_unique<ntuple<3>>(NN3, "wallx_coarsened_k",
-                                                  file_id);
-  wally_coarsened_k = std::make_unique<ntuple<3>>(NN3, "wally_coarsened_k",
-                                                  file_id);
-  wallz_coarsened_k = std::make_unique<ntuple<3>>(NN3, "wallz_coarsened_k",
-                                                  file_id);
+  int ncoarsen = measure->getNCoarsenSteps();
+  wallx_coarsened_k.resize(ncoarsen);
+  wally_coarsened_k.resize(ncoarsen);
+  wallz_coarsened_k.resize(ncoarsen);
+  for (int c = 0; c < ncoarsen; c++) {
+    std::string suffix = "_" + std::to_string(c + 1);
+    wallx_coarsened_k[c] = std::make_unique<ntuple<3>>(NN3, "wallx_coarsened_k" + suffix, file_id);
+    wally_coarsened_k[c] = std::make_unique<ntuple<3>>(NN3, "wally_coarsened_k" + suffix, file_id);
+    wallz_coarsened_k[c] = std::make_unique<ntuple<3>>(NN3, "wallz_coarsened_k" + suffix, file_id);
+  }
 }
 
 measurer_output_fasthdf5::~measurer_output_fasthdf5() { H5Fclose(file_id); }
@@ -148,16 +152,18 @@ void measurer_output_fasthdf5::save(const std::string &what) {
   wally_phase_k->fill();
   wallz_phase_k->fill();
 
-  std::memcpy(wallx_coarsened_k->row.data(), measure->wallXCoarse_k.v.data(),
-              wallx_coarsened_k->row.size() * sizeof(double));
-  std::memcpy(wally_coarsened_k->row.data(), measure->wallYCoarse_k.v.data(),
-              wally_coarsened_k->row.size() * sizeof(double));
-  std::memcpy(wallz_coarsened_k->row.data(), measure->wallZCoarse_k.v.data(),
-              wallz_coarsened_k->row.size() * sizeof(double));
+  for (int c = 0; c < measure->getNCoarsenSteps(); c++) {
+    std::memcpy(wallx_coarsened_k[c]->row.data(), measure->wallXCoarse_k[c].v.data(),
+                wallx_coarsened_k[c]->row.size() * sizeof(double));
+    std::memcpy(wally_coarsened_k[c]->row.data(), measure->wallYCoarse_k[c].v.data(),
+                wally_coarsened_k[c]->row.size() * sizeof(double));
+    std::memcpy(wallz_coarsened_k[c]->row.data(), measure->wallZCoarse_k[c].v.data(),
+                wallz_coarsened_k[c]->row.size() * sizeof(double));
 
-  wallx_coarsened_k->fill();
-  wally_coarsened_k->fill();
-  wallz_coarsened_k->fill();
+    wallx_coarsened_k[c]->fill();
+    wally_coarsened_k[c]->fill();
+    wallz_coarsened_k[c]->fill();
+  }
 }
 #endif
 

--- a/ModelG/measurer_output.cxx
+++ b/ModelG/measurer_output.cxx
@@ -69,12 +69,13 @@ measurer_output_fasthdf5::measurer_output_fasthdf5(Measurer *in,
   wallz_phase_k = std::make_unique<ntuple<3>>(NN3, "wallz_phase_k", file_id);
 
   NN3 = {Measurer::NObsCoarse, static_cast<size_t>(measure->getN()) / 2 + 1, 2};
-  int ncoarsen = measure->getNCoarsenSteps();
+  int ncoarsen = measure->getNCoarsenOutputs();
+  const auto &levels = measure->getCoarsenLevels();
   wallx_coarsened_k.resize(ncoarsen);
   wally_coarsened_k.resize(ncoarsen);
   wallz_coarsened_k.resize(ncoarsen);
   for (int c = 0; c < ncoarsen; c++) {
-    std::string suffix = "_" + std::to_string(c + 1);
+    std::string suffix = "_" + std::to_string(levels[c]);
     wallx_coarsened_k[c] = std::make_unique<ntuple<3>>(NN3, "wallx_coarsened_k" + suffix, file_id);
     wally_coarsened_k[c] = std::make_unique<ntuple<3>>(NN3, "wally_coarsened_k" + suffix, file_id);
     wallz_coarsened_k[c] = std::make_unique<ntuple<3>>(NN3, "wallz_coarsened_k" + suffix, file_id);
@@ -152,7 +153,7 @@ void measurer_output_fasthdf5::save(const std::string &what) {
   wally_phase_k->fill();
   wallz_phase_k->fill();
 
-  for (int c = 0; c < measure->getNCoarsenSteps(); c++) {
+  for (int c = 0; c < measure->getNCoarsenOutputs(); c++) {
     std::memcpy(wallx_coarsened_k[c]->row.data(), measure->wallXCoarse_k[c].v.data(),
                 wallx_coarsened_k[c]->row.size() * sizeof(double));
     std::memcpy(wally_coarsened_k[c]->row.data(), measure->wallYCoarse_k[c].v.data(),

--- a/ModelG/measurer_output.cxx
+++ b/ModelG/measurer_output.cxx
@@ -153,6 +153,10 @@ void measurer_output_fasthdf5::save(const std::string &what) {
   wally_phase_k->fill();
   wallz_phase_k->fill();
 
+}
+
+void measurer_output_fasthdf5::save_coarsen(const std::string &what) {
+
   for (int c = 0; c < measure->getNCoarsenOutputs(); c++) {
     std::memcpy(wallx_coarsened_k[c]->row.data(), measure->wallXCoarse_k[c].v.data(),
                 wallx_coarsened_k[c]->row.size() * sizeof(double));
@@ -165,7 +169,9 @@ void measurer_output_fasthdf5::save(const std::string &what) {
     wally_coarsened_k[c]->fill();
     wallz_coarsened_k[c]->fill();
   }
+
 }
+
 #endif
 
 /////////////////////////////////////////////////////////////////////////

--- a/ModelG/measurer_output.h
+++ b/ModelG/measurer_output.h
@@ -48,6 +48,7 @@ public:
   ~measurer_output_fasthdf5();
   //  Computes the contents of the data from measurer to the output file
   virtual void save(const std::string &what = "") override;
+  virtual void save_coarsen(const std::string &what = "") override;
 
 private:
   Measurer *measure;

--- a/ModelG/measurer_output.h
+++ b/ModelG/measurer_output.h
@@ -86,10 +86,10 @@ private:
   std::unique_ptr<ntuple<3>> wally_phase_k;
   std::unique_ptr<ntuple<3>> wallz_phase_k;
 
-  // Output of fourier coarsened info
-  std::unique_ptr<ntuple<3>> wallx_coarsened_k;
-  std::unique_ptr<ntuple<3>> wally_coarsened_k;
-  std::unique_ptr<ntuple<3>> wallz_coarsened_k;
+  // Output of fourier coarsened info; one ntuple per coarsen level (1..ncoarsen_steps)
+  std::vector<std::unique_ptr<ntuple<3>>> wallx_coarsened_k;
+  std::vector<std::unique_ptr<ntuple<3>>> wally_coarsened_k;
+  std::vector<std::unique_ptr<ntuple<3>>> wallz_coarsened_k;
 };
 #endif
 #endif

--- a/ModelG/measurer_output.h
+++ b/ModelG/measurer_output.h
@@ -55,6 +55,9 @@ private:
 
   // One dimensional quantities
   std::unique_ptr<ntuple<1>> scalars;
+  std::unique_ptr<ntuple<1>> energy;
+  std::unique_ptr<ntuple<1>> energy_rotated;
+  std::unique_ptr<ntuple<1>> energy_phase;
   // Time and mass of the measurement is also recorded.
   std::unique_ptr<ntuple<1>> timeout;
 
@@ -82,6 +85,11 @@ private:
   std::unique_ptr<ntuple<3>> wallx_phase_k;
   std::unique_ptr<ntuple<3>> wally_phase_k;
   std::unique_ptr<ntuple<3>> wallz_phase_k;
+
+  // Output of fourier coarsened info
+  std::unique_ptr<ntuple<3>> wallx_coarsened_k;
+  std::unique_ptr<ntuple<3>> wally_coarsened_k;
+  std::unique_ptr<ntuple<3>> wallz_coarsened_k;
 };
 #endif
 #endif


### PR DESCRIPTION
Added: Output of a solution at time t that is the orthogonal projection along a coarsened/diffused copy of the current.
 
This is done for solutions that are coarsened for i * dt time, where i takes value from 'ncoarsen_start' to 'ncoarsen_steps' with step_size = 'ncoarsen_stride'.